### PR TITLE
Do not import 'k6' js module just to reuse error

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/js/common"
-	"go.k6.io/k6/js/modules/k6"
 	"go.k6.io/k6/metrics"
 )
 
 func (mi *ModuleInstance) CheckStatus(wantStatus int, r *sobek.Object, extras ...sobek.Value) (bool, error) {
 	state := mi.vu.State()
 	if state == nil {
-		return false, k6.ErrCheckInInitContext
+		return false, errors.New("Using checkstatus in the init context is not supported")
 	}
 
 	if r == nil {


### PR DESCRIPTION
As part of preparations for 1.0.0 we are reducing the public API of k6 especialy in cases where it doesn't make sense

To this end https://github.com/grafana/k6/pull/4676 was opened in which the k6 js module code is being moved to `internal`.

This project is using this code in order to get an error. 

Also in this case the original error was not correct as it would say `check` instead of `checkstatus` 

Please merge this before v1.0.0 of k6 is released so that the extension doesn't stop working. You might also need to tag a release after that.